### PR TITLE
bug fix in wolframalpha

### DIFF
--- a/service/wolframalpha.py
+++ b/service/wolframalpha.py
@@ -15,8 +15,7 @@ class Main(base.RequestHandler):
 
     def get(self, *args):
         
-        query = urllib.unquote(args[1])
-        query = urllib.unquote_plus(query)
+        query = urllib.unquote_plus(args[1])
         query = urllib.urlencode({"i": query})
         
         if not query:


### PR DESCRIPTION
fixed the bug where a url encoded query string like '5%2B5' erroneously gets unquoted to '5 5' (interpretted by WA as 5*5) instead of '5+5'